### PR TITLE
[feat] Cloud Build 대응을 위한 Dockerfile 및 build.gradle 수정사항 반영

### DIFF
--- a/app-server/Dockerfile
+++ b/app-server/Dockerfile
@@ -7,5 +7,5 @@ RUN gradle build -x test
 # Step 2: Run
 FROM openjdk:17-jdk-slim
 WORKDIR /app
-COPY --from=builder /app/build/libs/*.jar app.jar
+COPY --from=builder /app/build/libs/app.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/app-server/build.gradle
+++ b/app-server/build.gradle
@@ -19,3 +19,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    archiveFileName = 'app.jar'
+}


### PR DESCRIPTION
### 주요 변경사항
- Dockerfile 수정
  - `COPY --from=builder /app/build/libs/*.jar app.jar` → `COPY --from=builder /app/build/libs/app.jar app.jar`
  - 빌드 시 복수 파일 매칭 이슈 해결
- build.gradle 수정
  - `jar { archiveFileName = 'app.jar' }` 추가
  - Gradle 빌드시 항상 app.jar로 고정되도록 설정
- Cloud Build → Cloud Run 배포 시 빌드 실패 오류 해결

### 추가 안내
- 이후 app-server 브랜치에서 dev를 pull 받아 Dockerfile, build.gradle 수정사항을 반영해야 함
