### PR TITLE
[fix] Cloud Run 배포 실패 수정 (bootJar 설정 추가)

### DIFF
--- a/app-server/build.gradle
+++ b/app-server/build.gradle
@@ -20,6 +20,6 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-jar {
+bootJar {
     archiveFileName = 'app.jar'
 }


### PR DESCRIPTION
### 주요 변경사항
- build.gradle 수정
  - 기존 jar 설정 제거
  - bootJar 설정 추가하여 실행 가능한 app.jar 생성
- Dockerfile 정상 동작 확인
- 로컬 Docker 컨테이너 및 Cloud Run 배포 정상화

### 변경 이유
- 기존 app.jar 파일에 Main-Class 정보가 없어 java -jar 명령어로 실행 불가
- Cloud Run 배포 시 컨테이너가 포트 8080에서 서버를 띄우지 못해 실패 발생
- 실행 가능한 Spring Boot jar를 생성하도록 수정하여 문제 해결