### PR TITLE
[chore] add cloudbuild.yaml and explicitly expose ports in Dockerfiles

### DIFF
--- a/ai-server/Dockerfile
+++ b/ai-server/Dockerfile
@@ -6,4 +6,5 @@ COPY . .
 RUN npm install
 RUN npm run build
 
+EXPOSE 8081
 CMD ["node", "dist/main"]

--- a/app-server/Dockerfile
+++ b/app-server/Dockerfile
@@ -8,4 +8,5 @@ RUN gradle build -x test
 FROM openjdk:17-jdk-slim
 WORKDIR /app
 COPY --from=builder /app/build/libs/app.jar app.jar
+EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,88 @@
+steps:
+  # 1. Build app-server
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-app-server:$COMMIT_SHA",
+        ".",
+        "-f",
+        "Dockerfile",
+      ]
+    dir: "app-server"
+    id: Build-app-server
+
+  # 2. Push app-server
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "push",
+        "asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-app-server:$COMMIT_SHA",
+      ]
+    id: Push-app-server
+
+  # 3. Build ai-server
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-ai-server:$COMMIT_SHA",
+        ".",
+        "-f",
+        "Dockerfile",
+      ]
+    dir: "ai-server"
+    id: Build-ai-server
+
+  # 4. Push ai-server
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "push",
+        "asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-ai-server:$COMMIT_SHA",
+      ]
+    id: Push-ai-server
+
+  # 5. Deploy app-server to Cloud Run
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      [
+        "run",
+        "deploy",
+        "minibuddy-app-server",
+        "--platform=managed",
+        "--region=asia-northeast3",
+        "--image=asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-app-server:$COMMIT_SHA",
+        "--port=8080",
+        "--allow-unauthenticated",
+        "--timeout=300",
+      ]
+    id: Deploy-app-server
+
+  # 6. Deploy ai-server to Cloud Run
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      [
+        "run",
+        "deploy",
+        "minibuddy-ai-server",
+        "--platform=managed",
+        "--region=asia-northeast3",
+        "--image=asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-ai-server:$COMMIT_SHA",
+        "--port=8081",
+        "--allow-unauthenticated",
+        "--timeout=300",
+      ]
+    id: Deploy-ai-server
+
+images:
+  - asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-app-server:$COMMIT_SHA
+  - asia-northeast3-docker.pkg.dev/minibuddy-456409/cloud-run-source-deploy/minibuddy-server/minibuddy-ai-server:$COMMIT_SHA
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  substitutionOption: ALLOW_LOOSE


### PR DESCRIPTION
### Summary
- Added `cloudbuild.yaml` to support automated deployment through Cloud Build.
- Updated Dockerfiles to explicitly expose necessary ports for Cloud Run detection:
  - `app-server`: expose 8080
  - `ai-server`: expose 8081

### Details
- cloudbuild.yaml defines build and deployment steps for multi-container setup (app-server, ai-server).
- Specified EXPOSE instructions in each Dockerfile to ensure correct port binding during Cloud Run deployment.
- Target branch for deployment is set to `dev`.